### PR TITLE
v0.0.1 - Formify column inputs

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -14,7 +14,7 @@ COPY app/pnpm-lock.yaml ./
 COPY app/package.json ./
 RUN pnpm install
 
-# cope the rest of the app
+# copy the rest of the app
 COPY app/ .
 
 # expose port

--- a/app/components/atoms/Column/Column.test.ts
+++ b/app/components/atoms/Column/Column.test.ts
@@ -162,13 +162,14 @@ describe('Column', () => {
 		const columnNameInput = wrapper.get('input[type="text"]');
 		expect((columnNameInput.element as HTMLInputElement).value).toBe(MOCK_COLUMN[1].name);
 
-		columnNameInput.trigger('focus');
+		await columnNameInput.trigger('focus');
 		await wrapper.vm.$nextTick();
 
-		columnNameInput.setValue('Updated Column Name');
+		await columnNameInput.setValue('Updated Column Name');
 		await wrapper.vm.$nextTick();
 
-		columnNameInput.trigger('blur');
+		await columnNameInput.trigger('blur');
+		await wrapper.vm.$nextTick();
 		await wrapper.vm.$nextTick();
 
 		expect((columnNameInput.element as HTMLInputElement).value).toBe('Updated Column Name');
@@ -185,13 +186,14 @@ describe('Column', () => {
 		const columnNameInput = wrapper.get('input[type="text"]');
 		expect((columnNameInput.element as HTMLInputElement).value).toBe(MOCK_COLUMN[1].name);
 
-		columnNameInput.trigger('focus');
+		await columnNameInput.trigger('focus');
 		await wrapper.vm.$nextTick();
 
-		columnNameInput.setValue('Updated Column Name');
+		await columnNameInput.setValue('Updated Column Name');
 		await wrapper.vm.$nextTick();
 
-		columnNameInput.trigger('keydown', { key: 'Enter' });
+		await columnNameInput.trigger('keyup', { key: 'Enter' });
+		await wrapper.vm.$nextTick();
 		await wrapper.vm.$nextTick();
 
 		expect((columnNameInput.element as HTMLInputElement).value).toBe('Updated Column Name');
@@ -213,13 +215,14 @@ describe('Column', () => {
 		const columnNameInput = wrapper.get('input[type="text"]');
 		expect((columnNameInput.element as HTMLInputElement).value).toBe(MOCK_COLUMN[1].name);
 
-		columnNameInput.trigger('focus');
+		await columnNameInput.trigger('focus');
 		await wrapper.vm.$nextTick();
 
-		columnNameInput.setValue('Updated Column Name');
+		await columnNameInput.setValue('Updated Column Name');
 		await wrapper.vm.$nextTick();
 
-		columnNameInput.trigger('blur');
+		await columnNameInput.trigger('blur');
+		await wrapper.vm.$nextTick();
 		await wrapper.vm.$nextTick();
 
 		expect(consoleErrorSpy).toHaveBeenCalledWith(expect.any(Error));

--- a/app/components/atoms/Column/Column.vue
+++ b/app/components/atoms/Column/Column.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
-import { computed, useTemplateRef, ref, watch } from 'vue';
+import { computed, reactive, useTemplateRef, ref, watch } from 'vue';
+import * as v from 'valibot';
 import { useColumnsStore } from '~/stores';
+import * as columnSchema from '~/schemas/columnSchema';
+import type { FormSubmitEvent } from '@nuxt/ui';
 
 const props = defineProps({
 	columnId: {
@@ -11,37 +14,31 @@ const props = defineProps({
 
 const columnsStore = useColumnsStore();
 const column = computed(() => columnsStore.getColumnById(props.columnId)!);
-
-const editColumnNameInputRef = useTemplateRef<HTMLInputElement>('editColumnNameInputRef');
-const columnNameInput = ref(column.value.name);
+const columnForm = useTemplateRef<HTMLFormElement>('columnForm');
+const columnFormSchema = v.object({ name: columnSchema.getNameValidator() });
+const columnFormState = reactive({ name: column.value.name });
 const isEditingColumnName = ref(false);
 
 watch(column, updatedColumn => {
-	columnNameInput.value = updatedColumn.name
+	columnFormState.name = updatedColumn.name;
 });
 
 const handleStartEditingColumnName = () => {
-	columnNameInput.value = column.value.name;
 	isEditingColumnName.value = true;
-}
+};
 
-// TODO: use `valibot` to validate the name
 const handleStopEditingColumnName = () => {
+	isEditingColumnName.value = false;
+	columnForm.value?.submit();
+};
+
+const handleSubmit = (event: FormSubmitEvent<v.InferOutput<typeof columnFormSchema>>) => {
 	try {
-		const columnName = columnNameInput.value.trim();
-		columnsStore.updateColumn(props.columnId, { name: columnName });
-		isEditingColumnName.value = false;
+		columnsStore.updateColumn(props.columnId, { name: event.data.name.trim() });
 	} catch (error) {
 		console.error(error);
 	}
-}
-
-const handleKeyDown = (event: KeyboardEvent) => {
-	if (event.key === 'Enter') {
-		event.preventDefault();
-		handleStopEditingColumnName();
-	}
-}
+};
 
 const baseClass = 'rounded-md flex flex-col flex-shrink-0 overflow-y-auto gap-2 p-2';
 const dimensionClass = 'w-full md:w-68 h-fit min-h-13 max-h-full ';
@@ -52,10 +49,14 @@ const darkThemeClass = 'dark:bg-gray-800';
 <template>
 	<div :class="[baseClass, dimensionClass, lightThemeClass, darkThemeClass]">
 		<div class="w-full flex justify-between items-center gap-2">
-			<UInput ref="editColumnNameInputRef" v-model="columnNameInput" type="text"
-				placeholder="Enter column name..." color="secondary" :highlight="isEditingColumnName"
-				class='w-full font-bold' size="lg" :variant="isEditingColumnName ? 'soft' : 'ghost'"
-				@focus="handleStartEditingColumnName" @blur="handleStopEditingColumnName" @keydown="handleKeyDown" />
+			<UForm ref="columnForm" :schema="columnFormSchema" :state="columnFormState" @submit="handleSubmit">
+				<UFormField name="name" size="lg">
+					<UInput v-model="columnFormState.name" type="text" placeholder="Enter column name..."
+						color="secondary" :highlight="isEditingColumnName" class='w-full font-bold' size="lg"
+						:variant="isEditingColumnName ? 'soft' : 'ghost'" @focus="handleStartEditingColumnName"
+						@blur="handleStopEditingColumnName" @keyup.enter="handleStopEditingColumnName" />
+				</UFormField>
+			</UForm>
 			<UIcon name="heroicons:arrows-up-down-solid"
 				class="size-5 draggable-column cursor-move ml-1 mr-3 md:hidden hover:cursor-grab active:cursor-grabbing" />
 			<UIcon name="heroicons:arrows-right-left-solid"

--- a/app/components/atoms/CreateColumn/CreateColumn.test.ts
+++ b/app/components/atoms/CreateColumn/CreateColumn.test.ts
@@ -164,18 +164,22 @@ describe('CreateColumn', () => {
 		});
 
 		const columnNameInput = wrapper.find('input');
-		columnNameInput.trigger('focus');
+		await columnNameInput.trigger('focus');
 		await wrapper.vm.$nextTick();
 
-		columnNameInput.setValue('New Column');
+		await columnNameInput.setValue('New Column');
 		await wrapper.vm.$nextTick();
 		expect(columnNameInput.element.value).toBe('New Column');
 		expect(boardsStore.getBoardById(MOCK_HASH[1])?.columnIds).toHaveLength(2);
 		expect(columnsStore.isValidColumnId(MOCK_HASH[6])).toBe(false);
 
 		vi.mocked(generateHash).mockReturnValueOnce(MOCK_HASH[6]);
-		columnNameInput.trigger('keydown', { key: 'Enter' });
+		await columnNameInput.trigger('keyup', { key: 'Enter' });
 		await wrapper.vm.$nextTick();
+		await wrapper.vm.$nextTick();
+		await wrapper.vm.$nextTick();
+		// yooo... wtf.... for some reason, you need to `await` the `.trigger`
+		// and call `.$nextTick` 3 times... wtf is this????
 
 		expect(columnNameInput.element.value).toBe('');
 		expect(columnsStore.isValidColumnId(MOCK_HASH[6])).toBe(true);
@@ -193,17 +197,19 @@ describe('CreateColumn', () => {
 		});
 
 		const columnNameInput = wrapper.find('input');
-		columnNameInput.trigger('focus');
+		await columnNameInput.trigger('focus');
 		await wrapper.vm.$nextTick();
 
-		columnNameInput.setValue('New Column');
+		await columnNameInput.setValue('New Column');
 		await wrapper.vm.$nextTick();
 		expect(columnNameInput.element.value).toBe('New Column');
 		expect(boardsStore.getBoardById(MOCK_HASH[1])?.columnIds).toHaveLength(2);
 		expect(columnsStore.isValidColumnId(MOCK_HASH[6])).toBe(false);
 
 		vi.mocked(generateHash).mockReturnValueOnce(MOCK_HASH[6]);
-		columnNameInput.trigger('blur');
+		await columnNameInput.trigger('blur');
+		await wrapper.vm.$nextTick();
+		await wrapper.vm.$nextTick();
 		await wrapper.vm.$nextTick();
 
 		expect(columnNameInput.element.value).toBe('');
@@ -222,21 +228,22 @@ describe('CreateColumn', () => {
 		});
 
 		const columnNameInput = wrapper.find('input');
-		columnNameInput.trigger('focus');
+		await columnNameInput.trigger('focus');
 		await wrapper.vm.$nextTick();
 
-		columnNameInput.setValue('New Column');
+		await columnNameInput.setValue('New Column');
 		await wrapper.vm.$nextTick();
 		expect(columnNameInput.element.value).toBe('New Column');
 		expect(boardsStore.getBoardById(MOCK_HASH[1])?.columnIds).toHaveLength(2);
 		expect(columnsStore.isValidColumnId(MOCK_HASH[6])).toBe(false);
 
-		columnNameInput.setValue('');
+		await columnNameInput.setValue('');
 		await wrapper.vm.$nextTick();
 		expect(columnNameInput.element.value).toBe('');
 
 		vi.mocked(generateHash).mockReturnValueOnce(MOCK_HASH[6]);
-		columnNameInput.trigger('blur');
+		await columnNameInput.trigger('blur');
+		await wrapper.vm.$nextTick();
 		await wrapper.vm.$nextTick();
 
 		expect(columnNameInput.element.value).toBe('');
@@ -245,9 +252,9 @@ describe('CreateColumn', () => {
 	});
 
 	it('should log an error if creating a column fails', async () => {
-		const columnStore = useColumnsStore();
+		const columnsStore = useColumnsStore();
 		const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-		vi.spyOn(columnStore, 'createColumn').mockImplementation(() => {
+		vi.spyOn(columnsStore, 'createColumn').mockImplementation(() => {
 			throw new Error('Failed to create column');
 		});
 
@@ -257,18 +264,19 @@ describe('CreateColumn', () => {
 		});
 
 		const columnNameInput = wrapper.find('input');
-		columnNameInput.trigger('focus');
+		await columnNameInput.trigger('focus');
 		await wrapper.vm.$nextTick();
 
-		columnNameInput.setValue('New Column');
+		await columnNameInput.setValue('New Column');
 		await wrapper.vm.$nextTick();
 		expect(columnNameInput.element.value).toBe('New Column');
 
 		vi.mocked(generateHash).mockReturnValueOnce(MOCK_HASH[6]);
-		columnNameInput.trigger('keydown', { key: 'Enter' });
+		await columnNameInput.trigger('keyup', { key: 'Enter' });
+		await wrapper.vm.$nextTick();
 		await wrapper.vm.$nextTick();
 
-		expect(consoleErrorSpy).toHaveBeenCalledWith(expect.any(Error));
+		expect(consoleErrorSpy).toHaveBeenCalled();
 
 		consoleErrorSpy.mockRestore();
 	});

--- a/app/components/atoms/CreateColumn/CreateColumn.vue
+++ b/app/components/atoms/CreateColumn/CreateColumn.vue
@@ -13,10 +13,10 @@ const props = defineProps({
 });
 
 const columnsStore = useColumnsStore();
-const isEditingColumnName = ref(false);
 const createColumnForm = useTemplateRef<HTMLFormElement>('createColumnForm');
 const createColumnFormSchema = v.object({ name: columnSchema.getNameValidator() });
 const createColumnFormState = reactive({ name: '' });
+const isEditingColumnName = ref(false);
 
 const handleStartEditingColumnName = () => {
 	isEditingColumnName.value = true;

--- a/app/components/atoms/CreateColumn/CreateColumn.vue
+++ b/app/components/atoms/CreateColumn/CreateColumn.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
-import { useTemplateRef, ref } from 'vue';
-import { useColumnsStore } from '~/stores';
+import { reactive, useTemplateRef, ref } from 'vue';
+import * as v from 'valibot';
+import { useColumnsStore } from '~/stores'
+import * as columnSchema from '~/schemas/columnSchema';
+import type { FormSubmitEvent } from '@nuxt/ui';
 
 const props = defineProps({
 	boardId: {
@@ -10,36 +13,30 @@ const props = defineProps({
 });
 
 const columnsStore = useColumnsStore();
-const createColumnInputRef = useTemplateRef<HTMLInputElement>('createColumnInputRef');
-const columnNameInput = ref('');
 const isEditingColumnName = ref(false);
+const createColumnForm = useTemplateRef<HTMLFormElement>('createColumnForm');
+const createColumnFormSchema = v.object({ name: columnSchema.getNameValidator() });
+const createColumnFormState = reactive({ name: '' });
 
 const handleStartEditingColumnName = () => {
 	isEditingColumnName.value = true;
-}
+};
 
-// TODO: use `valibot` to validate the name
 const handleStopEditingColumnName = () => {
-	try {
-		const columnName = columnNameInput.value.trim();
-		if (columnName.length === 0) {
-			isEditingColumnName.value = false;
-			return;
-		}
-		columnsStore.createColumn(props.boardId, { name: columnName });
-		columnNameInput.value = '';
-		isEditingColumnName.value = false;
-	} catch (error) {
-		console.error(error);
-	}
-}
+	isEditingColumnName.value = false;
+	createColumnForm.value?.submit();
+};
 
-const handleKeyDown = (event: KeyboardEvent) => {
-	if (event.key === 'Enter') {
-		event.preventDefault();
-		handleStopEditingColumnName();
+const handleSubmit = (event: FormSubmitEvent<v.InferOutput<typeof createColumnFormSchema>>) => {
+	try {
+		if (event.data.name.trim().length > 0) {
+			columnsStore.createColumn(props.boardId, { name: event.data.name.trim() });
+			createColumnFormState.name = '';
+		}
+	} catch (error) {
+		console.error(error)
 	}
-}
+};
 
 const baseClass = 'rounded-md flex-shrink-0 overflow-y-auto p-2 opacity-50 hover:opacity-100 transition-opacity duration-200 ease-in-out';
 const dimensionClass = 'w-full md:w-68 h-fit min-h-13';
@@ -49,9 +46,15 @@ const darkThemeClass = 'dark:bg-gray-800';
 
 <template>
 	<div :class="[baseClass, dimensionClass, lightThemeClass, darkThemeClass]">
-		<UInput ref="createColumnInputRef" v-model="columnNameInput" type="text" placeholder="Enter new column name..."
-			color="secondary" icon="heroicons:plus-solid" :highlight="isEditingColumnName" class='w-full font-bold'
-			size="lg" :variant="isEditingColumnName ? 'soft' : 'ghost'" @focus="handleStartEditingColumnName"
-			@blur="handleStopEditingColumnName" @keydown="handleKeyDown" />
+		<UForm ref="createColumnForm" :schema="createColumnFormSchema" :state="createColumnFormState"
+			@submit="handleSubmit">
+			<UFormField name="name" size="lg">
+				<UInput v-model="createColumnFormState.name" type="text" placeholder="Enter new column name..."
+					color="secondary" icon="heroicons:plus-solid" :highlight="isEditingColumnName"
+					class='w-full font-bold' size="lg" :variant="isEditingColumnName ? 'soft' : 'ghost'"
+					@focus="handleStartEditingColumnName" @blur="handleStopEditingColumnName"
+					@keyup.enter="handleStopEditingColumnName" />
+			</UFormField>
+		</UForm>
 	</div>
 </template>

--- a/app/components/organisms/Board/Board.vue
+++ b/app/components/organisms/Board/Board.vue
@@ -14,15 +14,15 @@ if (!boardsStore.isValidBoardId(route.params.id as string)) {
 	navigateTo('/boards')
 }
 
-const board = computed(() => boardsStore.getBoardById(boardId)!);
 const isEditBoardModalOpen = ref(false);
 const isEditingBoardName = ref(false);
-const form = useTemplateRef('form');
-const schema = v.object({ name: boardSchema.getNameValidator() });
-const state = reactive({ name: board.value.name });
+const board = computed(() => boardsStore.getBoardById(boardId)!);
+const boardForm = useTemplateRef<HTMLFormElement>('boardForm');
+const boardFormSchema = v.object({ name: boardSchema.getNameValidator() });
+const boardFormState = reactive({ name: board.value.name });
 
 watch(board, updatedBoard => {
-	state.name = updatedBoard.name;
+	boardFormState.name = updatedBoard.name;
 });
 
 const handleStartEditingBoardName = () => {
@@ -31,10 +31,10 @@ const handleStartEditingBoardName = () => {
 
 const handleStopEditingBoardName = () => {
 	isEditingBoardName.value = false;
-	form.value?.submit();
+	boardForm.value?.submit();
 };
 
-const handleSubmit = (event: FormSubmitEvent<v.InferOutput<typeof schema>>) => {
+const handleSubmit = (event: FormSubmitEvent<v.InferOutput<typeof boardFormSchema>>) => {
 	boardsStore.updateBoard(boardId, { name: event.data.name });
 };
 
@@ -76,10 +76,10 @@ const handleUpdateBoard = (updatedBoard: Partial<Board>) => {
 <template>
 	<div class="w-screen h-screen flex flex-col items-center gap-4 p-4">
 		<div class="w-fit min-w-68">
-			<UForm ref="form" :schema="schema" :state="state" @submit="handleSubmit">
+			<UForm ref="boardForm" :schema="boardFormSchema" :state="boardFormState" @submit="handleSubmit">
 				<UFormField name="name" size="lg" :ui="{ error: 'text-center' }">
-					<UInput v-model="state.name" type="text" placeholder="Enter board name..." color="secondary"
-						:highlight="isEditingBoardName" class='w-full font-bold' size="xl"
+					<UInput v-model="boardFormState.name" type="text" placeholder="Enter board name..."
+						color="secondary" :highlight="isEditingBoardName" class='w-full font-bold' size="xl"
 						:variant="isEditingBoardName ? 'soft' : 'ghost'" :ui="{ base: 'text-2xl text-center' }"
 						@focus="handleStartEditingBoardName" @blur="handleStopEditingBoardName" />
 				</UFormField>

--- a/app/components/organisms/Boards/Boards.vue
+++ b/app/components/organisms/Boards/Boards.vue
@@ -45,8 +45,7 @@ const handleViewBoard = (boardId: string) => {
 		<h1 class="font-bold text-3xl">Boards</h1>
 		<div class="w-full flex flex-wrap gap-4 justify-start">
 			<BoardPreview v-for="boardId of boardIds" :key="boardId" :name="boardMap[boardId].name"
-				:description="boardMap[boardId].description" :tags="boardMap[boardId].tags"
-				@view="handleViewBoard(boardId)" />
+				:description="boardMap[boardId].description" :tags="boardMap[boardId].tags" @view="handleViewBoard(boardId)" />
 		</div>
 	</UContainer>
 

--- a/app/schemas/columnSchema/columnSchema.test.ts
+++ b/app/schemas/columnSchema/columnSchema.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import * as v from 'valibot';
+import * as columnSchema from './columnSchema';
+
+describe('Column Schema Validators', () => {
+	it('should pass', () => {
+		expect(true).toBe(true);
+	});
+
+	describe('getIdValidator', () => {
+		it('should validate a valid ID', () => {
+			const result = v.safeParse(columnSchema.getIdValidator(), 'valid-id');
+			expect(result.success).toBe(true);
+		});
+
+		it('should invalidate an invalid ID', () => {
+			const result = v.safeParse(columnSchema.getIdValidator(), undefined);
+			expect(result.success).toBe(false);
+		});
+	});
+
+	describe('getNameValidator', () => {
+		it('should validate a valid name', () => {
+			const result = v.safeParse(columnSchema.getNameValidator(), 'Valid Column Name');
+			expect(result.success).toBe(true);
+		});
+
+		it('should invalidate a name that is too long', () => {
+			const result = v.safeParse(columnSchema.getNameValidator(), 'a'.repeat(33));
+			expect(result.success).toBe(false);
+			expect(result.issues![0].message).toContain(columnSchema.ERROR.NAME.MAX_LENGTH);
+		});
+	});
+});

--- a/app/schemas/columnSchema/columnSchema.ts
+++ b/app/schemas/columnSchema/columnSchema.ts
@@ -1,0 +1,15 @@
+import * as v from 'valibot';
+
+// TODO: localization
+// TODO: unit test
+export const ERROR = Object.freeze({
+	ID: {
+		NON_EMPTY: 'Column ID is required.'
+	},
+	NAME: Object.freeze({
+		MAX_LENGTH: 'Board name must be shorter than 32 characters.'
+	})
+});
+
+export const getIdValidator = () => v.pipe(v.string(), v.trim(), v.nonEmpty(ERROR.ID.NON_EMPTY));
+export const getNameValidator = () => v.pipe(v.string(), v.trim(), v.maxLength(32, ERROR.NAME.MAX_LENGTH));

--- a/app/schemas/columnSchema/index.ts
+++ b/app/schemas/columnSchema/index.ts
@@ -1,0 +1,1 @@
+export * from './columnSchema';


### PR DESCRIPTION
This PR wraps the `<UInput>` components in `Column.vue` and `CreateColumn.vue` with a `<UForm>` and `<UFormField>` to support current and future schema validations for column names.

This also adds support to showing validation error messages when interacting with the column-related input fields.