### PR TITLE
V0.0.2 - Formify card inputs

### DIFF
--- a/app/components/atoms/Card/Card.test.ts
+++ b/app/components/atoms/Card/Card.test.ts
@@ -147,13 +147,14 @@ describe('Card', () => {
 		});
 
 		const cardNameInput = wrapper.get('textarea');
-		cardNameInput.trigger('focus');
+		await cardNameInput.trigger('focus');
 		await wrapper.vm.$nextTick();
 
-		cardNameInput.setValue('Updated Card Name');
+		await cardNameInput.setValue('Updated Card Name');
 		await wrapper.vm.$nextTick();
 
-		cardNameInput.trigger('blur');
+		await cardNameInput.trigger('blur');
+		await wrapper.vm.$nextTick();
 		await wrapper.vm.$nextTick();
 
 		expect(cardNameInput.element.value).toBe('Updated Card Name');
@@ -168,13 +169,14 @@ describe('Card', () => {
 		});
 
 		const cardNameInput = wrapper.get('textarea');
-		cardNameInput.trigger('focus');
+		await cardNameInput.trigger('focus');
 		await wrapper.vm.$nextTick();
 
-		cardNameInput.setValue('Updated Card Name');
+		await cardNameInput.setValue('Updated Card Name');
 		await wrapper.vm.$nextTick();
 
-		cardNameInput.trigger('keydown', { key: 'Enter' });
+		await cardNameInput.trigger('keydown', { key: 'Enter' });
+		await wrapper.vm.$nextTick();
 		await wrapper.vm.$nextTick();
 
 		expect(cardNameInput.element.value).toBe('Updated Card Name');
@@ -194,13 +196,14 @@ describe('Card', () => {
 		});
 
 		const cardNameInput = wrapper.get('textarea');
-		cardNameInput.trigger('focus');
+		await cardNameInput.trigger('focus');
 		await wrapper.vm.$nextTick();
 
-		cardNameInput.setValue('Invalid Name');
+		await cardNameInput.setValue('Invalid Name');
 		await wrapper.vm.$nextTick();
 
-		cardNameInput.trigger('blur');
+		await cardNameInput.trigger('blur');
+		await wrapper.vm.$nextTick();
 		await wrapper.vm.$nextTick();
 
 		expect(consoleErrorSpy).toHaveBeenCalledWith(expect.any(Error));

--- a/app/components/atoms/Card/Card.vue
+++ b/app/components/atoms/Card/Card.vue
@@ -5,7 +5,6 @@ import { useCardsStore } from '~/stores';
 import * as cardSchema from '~/schemas/cardSchema';
 import type { FormSubmitEvent } from '@nuxt/ui';
 
-
 const props = defineProps({
 	cardId: {
 		type: String,

--- a/app/components/atoms/Card/Card.vue
+++ b/app/components/atoms/Card/Card.vue
@@ -1,6 +1,10 @@
 <script setup lang="ts">
-import { computed, useTemplateRef, ref, watch } from 'vue';
+import { computed, reactive, useTemplateRef, ref, watch } from 'vue';
+import * as v from 'valibot';
 import { useCardsStore } from '~/stores';
+import * as cardSchema from '~/schemas/cardSchema';
+import type { FormSubmitEvent } from '@nuxt/ui';
+
 
 const props = defineProps({
 	cardId: {
@@ -11,57 +15,55 @@ const props = defineProps({
 
 const cardsStore = useCardsStore();
 const card = computed(() => cardsStore.getCardById(props.cardId)!);
-
-const editCardNameInputRef = useTemplateRef<HTMLInputElement>('editCardNameInputRef');
-const cardNameInput = ref(card.value.name);
+const cardForm = useTemplateRef<HTMLFormElement>('cardForm');
+const cardFormSchema = v.object({ name: cardSchema.getNameValidator() });
+const cardFormState = reactive({ name: card.value.name });
 const isEditingCardName = ref(false);
 
 watch(card, updatedCard => {
-	cardNameInput.value = updatedCard.name
+	cardFormState.name = updatedCard.name
 });
 
 const handleStartEditingCardName = () => {
-	cardNameInput.value = card.value.name;
 	isEditingCardName.value = true;
-}
+};
 
-// TODO: use `valibot` to validate the name
-// TODO: wrap this in a try-catch block
 const handleStopEditingCardName = () => {
+	isEditingCardName.value = false;
+	cardForm.value?.submit();
+};
+
+const handleSubmit = (event: FormSubmitEvent<v.InferOutput<typeof cardFormSchema>>) => {
 	try {
-		const cardName = cardNameInput.value.trim();
-		cardsStore.updateCard(props.cardId, { name: cardName });
-		isEditingCardName.value = false;
+		cardsStore.updateCard(props.cardId, { name: event.data.name.trim() });
 	} catch (error) {
 		console.error(error);
 	}
-}
-
-// TODO: make this better
-const handleKeyDown = (event: KeyboardEvent) => {
-	if (event.key === 'Enter') {
-		event.preventDefault();
-		handleStopEditingCardName();
-	}
-}
+};
 
 const handleExpandCard = () => {
 	cardsStore.expandCard(props.cardId);
-}
+};
 
 const baseClass = 'rounded-md flex-shrink-0 p-2';
-const dimensionClass = 'w-full h-fit min-h-13 max'
-const lightThemeClass = 'bg-gray-100'
+const dimensionClass = 'w-full h-fit min-h-13 max';
+const lightThemeClass = 'bg-gray-100';
 const darkThemeClass = 'dark:bg-gray-600';
 </script>
 
 <template>
 	<div :class="[baseClass, dimensionClass, lightThemeClass, darkThemeClass]">
 		<div class="w-full flex justify-between items-start gap-1 pr-2">
-			<UTextarea ref="editCardNameInputRef" v-model="cardNameInput" placeholder="Enter card name..."
-				color="secondary" :highlight="isEditingCardName" class="w-full font-bold" size="lg"
-				:variant="isEditingCardName ? 'soft' : 'ghost'" :rows="1" :maxrows="0" autoresize :autoresizeDelay="0"
-				@focus="handleStartEditingCardName" @blur="handleStopEditingCardName" @keydown="handleKeyDown" />
+			<UForm ref="cardForm" :schema="cardFormSchema" :state="cardFormState" @submit="handleSubmit">
+				<UFormField name="name" size="lg">
+					<UTextarea v-model="cardFormState.name" placeholder="Enter card name..." color="secondary"
+						:highlight="isEditingCardName" class="w-full font-bold" size="lg"
+						:variant="isEditingCardName ? 'soft' : 'ghost'" :rows="1" :maxrows="0" autoresize
+						:autoresizeDelay="0" @focus="handleStartEditingCardName" @blur="handleStopEditingCardName"
+						@keydown.enter.prevent="handleStopEditingCardName" />
+				</UFormField>
+			</UForm>
+
 			<div class="w-fit h-fit flex gap-1 items-center">
 				<UButton icon="heroicons:arrows-pointing-out-20-solid" class="size-5 w-fit h-fit cursor-pointer"
 					variant="ghost" color="neutral" @click="handleExpandCard" />

--- a/app/components/atoms/Card/Card.vue
+++ b/app/components/atoms/Card/Card.vue
@@ -28,7 +28,8 @@ const handleStartEditingCardName = () => {
 	isEditingCardName.value = true;
 };
 
-const handleStopEditingCardName = () => {
+const handleStopEditingCardName = (event: KeyboardEvent) => {
+	(event.target as HTMLTextAreaElement).blur();
 	isEditingCardName.value = false;
 	cardForm.value?.submit();
 };

--- a/app/components/atoms/Column/Column.test.ts
+++ b/app/components/atoms/Column/Column.test.ts
@@ -192,7 +192,7 @@ describe('Column', () => {
 		await columnNameInput.setValue('Updated Column Name');
 		await wrapper.vm.$nextTick();
 
-		await columnNameInput.trigger('keyup', { key: 'Enter' });
+		await columnNameInput.trigger('keydown', { key: 'Enter' });
 		await wrapper.vm.$nextTick();
 		await wrapper.vm.$nextTick();
 

--- a/app/components/atoms/Column/Column.vue
+++ b/app/components/atoms/Column/Column.vue
@@ -54,7 +54,7 @@ const darkThemeClass = 'dark:bg-gray-800';
 					<UInput v-model="columnFormState.name" type="text" placeholder="Enter column name..."
 						color="secondary" :highlight="isEditingColumnName" class='w-full font-bold' size="lg"
 						:variant="isEditingColumnName ? 'soft' : 'ghost'" @focus="handleStartEditingColumnName"
-						@blur="handleStopEditingColumnName" @keyup.enter="handleStopEditingColumnName" />
+						@blur="handleStopEditingColumnName" @keydown.enter.prevent="handleStopEditingColumnName" />
 				</UFormField>
 			</UForm>
 			<UIcon name="heroicons:arrows-up-down-solid"

--- a/app/components/atoms/Column/Column.vue
+++ b/app/components/atoms/Column/Column.vue
@@ -27,7 +27,8 @@ const handleStartEditingColumnName = () => {
 	isEditingColumnName.value = true;
 };
 
-const handleStopEditingColumnName = () => {
+const handleStopEditingColumnName = (event: KeyboardEvent) => {
+	(event.target as HTMLTextAreaElement).blur();
 	isEditingColumnName.value = false;
 	columnForm.value?.submit();
 };

--- a/app/components/atoms/CreateCard/CreateCard.test.ts
+++ b/app/components/atoms/CreateCard/CreateCard.test.ts
@@ -164,17 +164,19 @@ describe('CreateCard', () => {
 		});
 
 		const cardNameInput = wrapper.find('textarea');
-		cardNameInput.trigger('focus');
+		await cardNameInput.trigger('focus');
 		await wrapper.vm.$nextTick();
 
-		cardNameInput.setValue('New Card Name');
+		await cardNameInput.setValue('New Card Name');
 		await wrapper.vm.$nextTick();
 		expect(cardNameInput.element.value).toBe('New Card Name');
 		expect(columnsStore.getColumnById(MOCK_HASH[2])?.cardIds).toHaveLength(1);
 		expect(cardsStore.isValidCardId(MOCK_HASH[6])).toBe(false);
 
 		vi.mocked(generateHash).mockReturnValueOnce(MOCK_HASH[6]);
-		cardNameInput.trigger('keydown', { key: 'Enter' });
+		await cardNameInput.trigger('keydown', { key: 'Enter' });
+		await wrapper.vm.$nextTick();
+		await wrapper.vm.$nextTick();
 		await wrapper.vm.$nextTick();
 
 		expect(cardNameInput.element.value).toBe('');
@@ -193,17 +195,19 @@ describe('CreateCard', () => {
 		});
 
 		const cardNameInput = wrapper.find('textarea');
-		cardNameInput.trigger('focus');
+		await cardNameInput.trigger('focus');
 		await wrapper.vm.$nextTick();
 
-		cardNameInput.setValue('New Card Name');
+		await cardNameInput.setValue('New Card Name');
 		await wrapper.vm.$nextTick();
 		expect(cardNameInput.element.value).toBe('New Card Name');
 		expect(columnsStore.getColumnById(MOCK_HASH[2])?.cardIds).toHaveLength(1);
 		expect(cardsStore.isValidCardId(MOCK_HASH[6])).toBe(false);
 
 		vi.mocked(generateHash).mockReturnValueOnce(MOCK_HASH[6]);
-		cardNameInput.trigger('blur');
+		await cardNameInput.trigger('blur');
+		await wrapper.vm.$nextTick();
+		await wrapper.vm.$nextTick();
 		await wrapper.vm.$nextTick();
 
 		expect(cardNameInput.element.value).toBe('');
@@ -222,20 +226,20 @@ describe('CreateCard', () => {
 		});
 
 		const cardNameInput = wrapper.find('textarea');
-		cardNameInput.trigger('focus');
+		await cardNameInput.trigger('focus');
 		await wrapper.vm.$nextTick();
 
-		cardNameInput.setValue('New Card Name');
+		await cardNameInput.setValue('New Card Name');
 		await wrapper.vm.$nextTick();
 		expect(cardNameInput.element.value).toBe('New Card Name');
 		expect(columnsStore.getColumnById(MOCK_HASH[2])?.cardIds).toHaveLength(1);
 		expect(cardsStore.isValidCardId(MOCK_HASH[6])).toBe(false);
 
-		cardNameInput.setValue('');
+		await cardNameInput.setValue('');
 		await wrapper.vm.$nextTick();
 		expect(cardNameInput.element.value).toBe('');
 
-		cardNameInput.trigger('blur');
+		await cardNameInput.trigger('blur');
 		await wrapper.vm.$nextTick();
 
 		expect(cardNameInput.element.value).toBe('');
@@ -255,15 +259,16 @@ describe('CreateCard', () => {
 		});
 
 		const cardNameInput = wrapper.find('textarea');
-		cardNameInput.trigger('focus');
+		await cardNameInput.trigger('focus');
 		await wrapper.vm.$nextTick();
 
-		cardNameInput.setValue('New Card Name');
+		await cardNameInput.setValue('New Card Name');
 		await wrapper.vm.$nextTick();
 		expect(cardNameInput.element.value).toBe('New Card Name');
 
 		vi.mocked(generateHash).mockReturnValueOnce(MOCK_HASH[6]);
-		cardNameInput.trigger('keydown', { key: 'Enter' });
+		await cardNameInput.trigger('keydown', { key: 'Enter' });
+		await wrapper.vm.$nextTick();
 		await wrapper.vm.$nextTick();
 
 		expect(consoleErrorSpy).toHaveBeenCalledWith(expect.any(Error));

--- a/app/components/atoms/CreateColumn/CreateColumn.test.ts
+++ b/app/components/atoms/CreateColumn/CreateColumn.test.ts
@@ -174,7 +174,7 @@ describe('CreateColumn', () => {
 		expect(columnsStore.isValidColumnId(MOCK_HASH[6])).toBe(false);
 
 		vi.mocked(generateHash).mockReturnValueOnce(MOCK_HASH[6]);
-		await columnNameInput.trigger('keyup', { key: 'Enter' });
+		await columnNameInput.trigger('keydown', { key: 'Enter' });
 		await wrapper.vm.$nextTick();
 		await wrapper.vm.$nextTick();
 		await wrapper.vm.$nextTick();
@@ -272,7 +272,7 @@ describe('CreateColumn', () => {
 		expect(columnNameInput.element.value).toBe('New Column');
 
 		vi.mocked(generateHash).mockReturnValueOnce(MOCK_HASH[6]);
-		await columnNameInput.trigger('keyup', { key: 'Enter' });
+		await columnNameInput.trigger('keydown', { key: 'Enter' });
 		await wrapper.vm.$nextTick();
 		await wrapper.vm.$nextTick();
 

--- a/app/components/atoms/CreateColumn/CreateColumn.vue
+++ b/app/components/atoms/CreateColumn/CreateColumn.vue
@@ -53,7 +53,7 @@ const darkThemeClass = 'dark:bg-gray-800';
 					color="secondary" icon="heroicons:plus-solid" :highlight="isEditingColumnName"
 					class='w-full font-bold' size="lg" :variant="isEditingColumnName ? 'soft' : 'ghost'"
 					@focus="handleStartEditingColumnName" @blur="handleStopEditingColumnName"
-					@keyup.enter="handleStopEditingColumnName" />
+					@keydown.enter.prevent="handleStopEditingColumnName" />
 			</UFormField>
 		</UForm>
 	</div>

--- a/app/schemas/cardSchema/cardSchema.test.ts
+++ b/app/schemas/cardSchema/cardSchema.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import * as v from 'valibot';
+import * as cardSchema from './cardSchema';
+
+describe('Card Schema Validators', () => {
+	describe('getIdValidator', () => {
+		it('should validate a valid ID', () => {
+			const result = v.safeParse(cardSchema.getIdValidator(), 'valid-id');
+			expect(result.success).toBe(true);
+		});
+
+		it('should invalidate an invalid ID', () => {
+			const result = v.safeParse(cardSchema.getIdValidator(), undefined);
+			expect(result.success).toBe(false);
+		});
+	});
+
+	describe('getNameValidator', () => {
+		it('should validate a valid name', () => {
+			const result = v.safeParse(cardSchema.getNameValidator(), 'Valid Card Name');
+			expect(result.success).toBe(true);
+		});
+
+		it('should invalidate a name that is too long', () => {
+			const result = v.safeParse(cardSchema.getNameValidator(), 'a'.repeat(65));
+			expect(result.success).toBe(false);
+			expect(result.issues![0].message).toContain(cardSchema.ERROR.NAME.MAX_LENGTH);
+		});
+	});
+});

--- a/app/schemas/cardSchema/cardSchema.ts
+++ b/app/schemas/cardSchema/cardSchema.ts
@@ -1,0 +1,15 @@
+import * as v from 'valibot';
+
+// TODO: localization
+// TODO: unit test
+export const ERROR = Object.freeze({
+	ID: {
+		NON_EMPTY: 'Card ID is required.'
+	},
+	NAME: Object.freeze({
+		MAX_LENGTH: 'Card name must be shorter than 64 characters.'
+	})
+});
+
+export const getIdValidator = () => v.pipe(v.string(), v.trim(), v.nonEmpty(ERROR.ID.NON_EMPTY));
+export const getNameValidator = () => v.pipe(v.string(), v.trim(), v.maxLength(64, ERROR.NAME.MAX_LENGTH));

--- a/app/schemas/cardSchema/index.ts
+++ b/app/schemas/cardSchema/index.ts
@@ -1,0 +1,1 @@
+export * from './cardSchema';

--- a/app/schemas/columnSchema/columnSchema.test.ts
+++ b/app/schemas/columnSchema/columnSchema.test.ts
@@ -3,10 +3,6 @@ import * as v from 'valibot';
 import * as columnSchema from './columnSchema';
 
 describe('Column Schema Validators', () => {
-	it('should pass', () => {
-		expect(true).toBe(true);
-	});
-
 	describe('getIdValidator', () => {
 		it('should validate a valid ID', () => {
 			const result = v.safeParse(columnSchema.getIdValidator(), 'valid-id');


### PR DESCRIPTION
This PR wraps the `<UInput>` components in `Card.vue` and `CreateCard.vue` with a `<UForm>` and `<UFormField>` to support current and future schema validations for card names.

This also adds support to showing validation error messages when interacting with the card-related input fields.