### PR TITLE
v0.1.5 - Reusable Atom Components

### DIFF
--- a/app/components/atoms/Buttons/ArchiveButton/ArchiveButton.test.ts
+++ b/app/components/atoms/Buttons/ArchiveButton/ArchiveButton.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { mountSuspended } from '@nuxt/test-utils/runtime';
+import ArchiveButton from './ArchiveButton.vue';
+
+describe('ArchiveButton', () => {
+  it('renders the `Archive` button', async () => {
+    const wrapper = await mountSuspended(ArchiveButton);
+    expect(wrapper.text()).toContain('Archive');
+  });
+
+  it('emits `archive` event when clicked', async () => {
+    const wrapper = await mountSuspended(ArchiveButton);
+    await wrapper.find('button').trigger('click');
+    expect(wrapper.emitted('archive')).toBeTruthy();
+    expect(wrapper.emitted('archive')!.length).toBe(1);
+  });
+});

--- a/app/components/atoms/Buttons/ArchiveButton/ArchiveButton.vue
+++ b/app/components/atoms/Buttons/ArchiveButton/ArchiveButton.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+const emit = defineEmits(['archive']);
+
+const handleArchive = () => {
+	emit('archive');
+};
+</script>
+
+<template>
+	<UButton label="Archive" color="secondary" variant="ghost" @click="handleArchive" />
+</template>

--- a/app/components/atoms/Buttons/CancelButton/CancelButton.test.ts
+++ b/app/components/atoms/Buttons/CancelButton/CancelButton.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { mountSuspended } from '@nuxt/test-utils/runtime';
+import CancelButton from './CancelButton.vue';
+
+describe('CancelButton', () => {
+  it('renders the cancel button', async () => {
+	const wrapper = await mountSuspended(CancelButton);
+	expect(wrapper.text()).toContain('Cancel');
+  });
+
+  it('emits `cancel` event when clicked', async () => {
+	const wrapper = await mountSuspended(CancelButton);
+	await wrapper.find('button').trigger('click');
+	expect(wrapper.emitted('cancel')).toBeTruthy();
+	expect(wrapper.emitted('cancel')!.length).toBe(1);
+  });
+});

--- a/app/components/atoms/Buttons/CancelButton/CancelButton.vue
+++ b/app/components/atoms/Buttons/CancelButton/CancelButton.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+const emit = defineEmits(['cancel']);
+
+const handleCancel = () => {
+	emit('cancel');
+};
+</script>
+
+<template>
+	<UButton label="Cancel" color="error" variant="soft" @click="handleCancel" />
+</template>

--- a/app/components/atoms/Buttons/CloseButton/CloseButton.test.ts
+++ b/app/components/atoms/Buttons/CloseButton/CloseButton.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { mountSuspended } from '@nuxt/test-utils/runtime';
+import CloseButton from './CloseButton.vue';
+
+describe('CloseButton', () => {
+  it('renders the close button', async () => {
+	const wrapper = await mountSuspended(CloseButton);
+	expect(wrapper.text()).toContain('Close');
+  });
+
+  it('emits `close` event when clicked', async () => {
+	const wrapper = await mountSuspended(CloseButton);
+	await wrapper.find('button').trigger('click');
+	expect(wrapper.emitted('close')).toBeTruthy();
+	expect(wrapper.emitted('close')!.length).toBe(1);
+  });
+});

--- a/app/components/atoms/Buttons/CloseButton/CloseButton.vue
+++ b/app/components/atoms/Buttons/CloseButton/CloseButton.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+const emit = defineEmits(['close']);
+
+const handleClose = () => {
+	emit('close');
+};
+</script>
+
+<template>
+	<UButton label="Close" color="neutral" variant="ghost" @click="handleClose" />
+</template>

--- a/app/components/atoms/Buttons/CreateBoardButton/CreateBoardButton.vue
+++ b/app/components/atoms/Buttons/CreateBoardButton/CreateBoardButton.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 const emit = defineEmits(['create']);
+
 const handleCreate = () => {
 	emit('create');
 };

--- a/app/components/atoms/Buttons/DeleteButton/DeleteButton.test.ts
+++ b/app/components/atoms/Buttons/DeleteButton/DeleteButton.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { mountSuspended } from '@nuxt/test-utils/runtime';
+import DeleteButton from './DeleteButton.vue';
+
+describe('DeleteButton', () => {
+  it('renders the delete button', async () => {
+	const wrapper = await mountSuspended(DeleteButton);
+	expect(wrapper.text()).toContain('Delete');
+  });
+
+  it('emits `delete` event when clicked', async () => {
+	const wrapper = await mountSuspended(DeleteButton);
+	await wrapper.find('button').trigger('click');
+	expect(wrapper.emitted('delete')).toBeTruthy();
+	expect(wrapper.emitted('delete')!.length).toBe(1);
+  });
+});

--- a/app/components/atoms/Buttons/DeleteButton/DeleteButton.vue
+++ b/app/components/atoms/Buttons/DeleteButton/DeleteButton.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+const emit = defineEmits(['delete']);
+
+const handleDelete = () => {
+	emit('delete');
+};
+</script>
+
+<template>
+	<UButton label="Delete" color="error" variant="soft" @click="handleDelete" />
+</template>

--- a/app/components/atoms/Buttons/EditBoardButton/EditBoardButton.vue
+++ b/app/components/atoms/Buttons/EditBoardButton/EditBoardButton.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 const emit = defineEmits(['edit']);
+
 const handleEdit = () => {
 	emit('edit');
 };

--- a/app/components/atoms/Buttons/EditButton/EditButton.test.ts
+++ b/app/components/atoms/Buttons/EditButton/EditButton.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { mountSuspended } from '@nuxt/test-utils/runtime';
+import EditButton from './EditButton.vue';
+
+describe('EditButton', () => {
+  it('renders the edit button', async () => {
+	const wrapper = await mountSuspended(EditButton);
+	expect(wrapper.text()).toContain('Edit');
+  });
+
+  it('emits `edit` event when clicked', async () => {
+	const wrapper = await mountSuspended(EditButton);
+	await wrapper.find('button').trigger('click');
+	expect(wrapper.emitted('edit')).toBeTruthy();
+	expect(wrapper.emitted('edit')!.length).toBe(1);
+  });
+});

--- a/app/components/atoms/Buttons/EditButton/EditButton.vue
+++ b/app/components/atoms/Buttons/EditButton/EditButton.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+const emit = defineEmits(['edit']);
+
+const handleEdit = () => {
+	emit('edit');
+};
+</script>
+
+<template>
+	<UButton label="Edit" color="secondary" @click="handleEdit" />
+</template>

--- a/app/components/atoms/Buttons/ToggleArchivedBoardsButton/ToggleArchivedBoardsButton.test.ts
+++ b/app/components/atoms/Buttons/ToggleArchivedBoardsButton/ToggleArchivedBoardsButton.test.ts
@@ -1,33 +1,36 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { setActivePinia, createPinia } from 'pinia';
-import { mount } from '@vue/test-utils';
+import { mountSuspended } from '@nuxt/test-utils/runtime';
 import { useSettingsStore } from '~/stores';
 import ToggleArchivedBoardsButton from './ToggleArchivedBoardsButton.vue';
 
 describe('ToggleArchivedBoardsButton', () => {
-	let settingsStore: ReturnType<typeof useSettingsStore>;
+	let pinia: any;
 
 	beforeEach(() => {
-		setActivePinia(createPinia());
-		settingsStore = useSettingsStore();
-		settingsStore.setShowArchivedBoards(false);
+		vi.resetAllMocks();
+		pinia = createPinia();
+		setActivePinia(pinia);
 	});
 
-	it('renders "Show archived boards" when `showArchivedBoards` is `false`', () => {
-		const wrapper = mount(ToggleArchivedBoardsButton);
+	it('renders "Show archived boards" when `showArchivedBoards` is `false`', async () => {
+		const settingsStore = useSettingsStore();
+		const wrapper = await mountSuspended(ToggleArchivedBoardsButton, { global: { plugins: [pinia] } });
 		expect(wrapper.text()).toContain('Show archived boards');
 		expect(settingsStore.showArchivedBoards).toBe(false);
 	});
 
 	it('renders "Hide archived boards" when `showArchivedBoards` is `true`', async () => {
+		const settingsStore = useSettingsStore();
 		settingsStore.setShowArchivedBoards(true);
-		const wrapper = mount(ToggleArchivedBoardsButton);
+		const wrapper = await mountSuspended(ToggleArchivedBoardsButton, { global: { plugins: [pinia] } });
 		expect(wrapper.text()).toContain('Hide archived boards');
 		expect(settingsStore.showArchivedBoards).toBe(true);
 	});
 
 	it('toggles `showArchivedBoards` on click', async () => {
-		const wrapper = mount(ToggleArchivedBoardsButton);
+		const settingsStore = useSettingsStore();
+		const wrapper = await mountSuspended(ToggleArchivedBoardsButton, { global: { plugins: [pinia] } });
 		const button = wrapper.find('button');
 		await button.trigger('click');
 		expect(settingsStore.showArchivedBoards).toBe(true);

--- a/app/components/atoms/Buttons/ToggleArchivedCardsButton/ToggleArchivedCardsButton.test.ts
+++ b/app/components/atoms/Buttons/ToggleArchivedCardsButton/ToggleArchivedCardsButton.test.ts
@@ -1,33 +1,36 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { setActivePinia, createPinia } from 'pinia';
-import { mount } from '@vue/test-utils';
+import { mountSuspended } from '@nuxt/test-utils/runtime';
 import { useSettingsStore } from '~/stores';
 import ToggleArchivedCardsButton from './ToggleArchivedCardsButton.vue';
 
 describe('ToggleArchivedCardsButton', () => {
-	let settingsStore: ReturnType<typeof useSettingsStore>;
+	let pinia: any;
 
 	beforeEach(() => {
-		setActivePinia(createPinia());
-		settingsStore = useSettingsStore();
-		settingsStore.setShowArchivedCards(false);
+		vi.resetAllMocks();
+		pinia = createPinia();
+		setActivePinia(pinia);
 	});
 
-	it('renders "Show archived cards" when `showArchivedCards` is `false`', () => {
-		const wrapper = mount(ToggleArchivedCardsButton);
-		expect(wrapper.text()).toContain('Show archived cards');
+	it('renders "Show archived cards" when `showArchivedCards` is `false`', async () => {
+		const settingsStore = useSettingsStore();
+		const wrapper = await mountSuspended(ToggleArchivedCardsButton, { global: { plugins: [pinia] } });
 		expect(settingsStore.showArchivedCards).toBe(false);
+		expect(wrapper.text()).toContain('Show archived cards');
 	});
 
 	it('renders "Hide archived cards" when `showArchivedCards` is `true`', async () => {
+		const settingsStore = useSettingsStore();
 		settingsStore.setShowArchivedCards(true);
-		const wrapper = mount(ToggleArchivedCardsButton);
+		const wrapper = await mountSuspended(ToggleArchivedCardsButton, { global: { plugins: [pinia] } });
 		expect(wrapper.text()).toContain('Hide archived cards');
 		expect(settingsStore.showArchivedCards).toBe(true);
 	});
 
 	it('toggles `showArchivedCards` on click', async () => {
-		const wrapper = mount(ToggleArchivedCardsButton);
+		const settingsStore = useSettingsStore();
+		const wrapper = await mountSuspended(ToggleArchivedCardsButton, { global: { plugins: [pinia] } });
 		const button = wrapper.find('button');
 		await button.trigger('click');
 		expect(settingsStore.showArchivedCards).toBe(true);

--- a/app/components/atoms/Buttons/ToggleArchivedColumnsButton/ToggleArchivedColumnsButton.test.ts
+++ b/app/components/atoms/Buttons/ToggleArchivedColumnsButton/ToggleArchivedColumnsButton.test.ts
@@ -1,33 +1,36 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { setActivePinia, createPinia } from 'pinia';
-import { mount } from '@vue/test-utils';
+import { mountSuspended } from '@nuxt/test-utils/runtime';
 import { useSettingsStore } from '~/stores';
 import ToggleArchivedColumnsButton from './ToggleArchivedColumnsButton.vue';
 
 describe('ToggleArchivedColumnsButton', () => {
-	let settingsStore: ReturnType<typeof useSettingsStore>;
+	let pinia: any;
 
 	beforeEach(() => {
-		setActivePinia(createPinia());
-		settingsStore = useSettingsStore();
-		settingsStore.setShowArchivedColumns(false);
+		vi.resetAllMocks();
+		pinia = createPinia();
+		setActivePinia(pinia);
 	});
 
-	it('renders "Show archived columns" when `showArchivedColumns` is `false`', () => {
-		const wrapper = mount(ToggleArchivedColumnsButton);
+	it('renders "Show archived columns" when `showArchivedColumns` is `false`', async () => {
+		const settingsStore = useSettingsStore();
+		const wrapper = await mountSuspended(ToggleArchivedColumnsButton, { global: { plugins: [pinia] } });
 		expect(wrapper.text()).toContain('Show archived columns');
 		expect(settingsStore.showArchivedColumns).toBe(false);
 	});
 
 	it('renders "Hide archived columns" when `showArchivedColumns` is `true`', async () => {
+		const settingsStore = useSettingsStore();
 		settingsStore.setShowArchivedColumns(true);
-		const wrapper = mount(ToggleArchivedColumnsButton);
+		const wrapper = await mountSuspended(ToggleArchivedColumnsButton, { global: { plugins: [pinia] } });
 		expect(wrapper.text()).toContain('Hide archived columns');
 		expect(settingsStore.showArchivedColumns).toBe(true);
 	});
 
 	it('toggles `showArchivedColumns` on click', async () => {
-		const wrapper = mount(ToggleArchivedColumnsButton);
+		const settingsStore = useSettingsStore();
+		const wrapper = await mountSuspended(ToggleArchivedColumnsButton, { global: { plugins: [pinia] } });
 		const button = wrapper.find('button');
 		await button.trigger('click');
 		expect(settingsStore.showArchivedColumns).toBe(true);

--- a/app/components/atoms/Buttons/UnarchiveButton/UnarchiveButton.test.ts
+++ b/app/components/atoms/Buttons/UnarchiveButton/UnarchiveButton.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { mountSuspended } from '@nuxt/test-utils/runtime';
+import UnarchiveButton from './UnarchiveButton.vue';
+
+describe('UnarchiveButton', () => {
+  it('renders the unarchive button', async () => {
+	const wrapper = await mountSuspended(UnarchiveButton);
+	expect(wrapper.text()).toContain('Unarchive');
+  });
+
+  it('emits `unarchive` event when clicked', async () => {
+	const wrapper = await mountSuspended(UnarchiveButton);
+	await wrapper.find('button').trigger('click');
+	expect(wrapper.emitted('unarchive')).toBeTruthy();
+	expect(wrapper.emitted('unarchive')!.length).toBe(1);
+  });
+});

--- a/app/components/atoms/Buttons/UnarchiveButton/UnarchiveButton.vue
+++ b/app/components/atoms/Buttons/UnarchiveButton/UnarchiveButton.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+const emit = defineEmits(['unarchive']);
+
+const handleUnarchive = () => {
+	emit('unarchive');
+};
+</script>
+
+<template>
+	<UButton label="Unarchive" color="secondary" variant="ghost" @click="handleUnarchive" />
+</template>

--- a/app/components/atoms/Buttons/UpdateButton/UpdateButton.test.ts
+++ b/app/components/atoms/Buttons/UpdateButton/UpdateButton.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { mountSuspended } from '@nuxt/test-utils/runtime';
+import UpdateButton from './UpdateButton.vue';
+
+describe('UpdateButton', () => {
+  it('renders the update button', async () => {
+	const wrapper = await mountSuspended(UpdateButton);
+	expect(wrapper.text()).toContain('Update');
+  });
+
+  it('emits `update` event when clicked', async () => {
+	const wrapper = await mountSuspended(UpdateButton);
+	await wrapper.find('button').trigger('click');
+	expect(wrapper.emitted('update')).toBeTruthy();
+	expect(wrapper.emitted('update')!.length).toBe(1);
+  });
+});

--- a/app/components/atoms/Buttons/UpdateButton/UpdateButton.vue
+++ b/app/components/atoms/Buttons/UpdateButton/UpdateButton.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+const emit = defineEmits(['update']);
+
+const handleUpdate = () => {
+	emit('update');
+};
+</script>
+
+<template>
+	<UButton label="Update" color="primary" @click="handleUpdate" />
+</template>

--- a/app/components/atoms/Column/Column.vue
+++ b/app/components/atoms/Column/Column.vue
@@ -78,10 +78,9 @@ const darkThemeClass = 'dark:bg-gray-800';
 		</div>
 		<Cards :columnId="column.id" :cardIds="column.cardIds" />
 		<div class="w-full flex justify-between items-center gap-2">
-			<UButton v-if="!column.archived" label="Archive" color="secondary" variant="ghost"
-				@click="handleArchiveColumn" />
-			<UButton v-else label="Unarchive" color="secondary" variant="ghost" @click="handleUnarchiveColumn" />
-			<UButton v-if="column.archived" label="Delete" color="error" variant="soft" @click="handleDeleteColumn" />
+			<ArchiveButton v-if="!column.archived" @archive="handleArchiveColumn" />
+			<UnarchiveButton v-else @unarchive="handleUnarchiveColumn" />
+			<DeleteButton v-if="column.archived" @delete="handleDeleteColumn" />
 		</div>
 	</div>
 </template>

--- a/app/components/molecules/BoardPreview/BoardPreview.vue
+++ b/app/components/molecules/BoardPreview/BoardPreview.vue
@@ -15,6 +15,7 @@ defineProps({
 });
 
 const emit = defineEmits(['view']);
+
 const handleViewBoard = (() => {
 	emit('view')
 });

--- a/app/components/molecules/CreateBoardModal/CreateBoardModal.vue
+++ b/app/components/molecules/CreateBoardModal/CreateBoardModal.vue
@@ -10,6 +10,7 @@ const props = defineProps({
 		required: true
 	},
 });
+
 const emit = defineEmits(['close', 'create']);
 
 const form = useTemplateRef('form');
@@ -37,14 +38,11 @@ const resetFormState = () => {
 
 const handleCreateBoardTag = () => {
 	form.value?.validate({ name: 'tag', silent: true });
-	const rawTag = (formState.tag ?? '').trim();
-	const result = v.safeParse(v.pipe(v.string(), v.trim(), v.minLength(2), v.maxLength(16)), rawTag);
+	const result = v.safeParse(v.pipe(v.string(), v.trim(), v.minLength(2), v.maxLength(16)), formState.tag);
 	if (result.success) {
-		formState.tags.add(rawTag);
+		formState.tags.add(formState.tag!);
 		formState.tag = undefined;
 	}
-	// TODO: Figure out why this is not being covered by coverage report
-	/* c8 ignore next */
 };
 
 const handleDeleteBoardTag = (tag: string) => {
@@ -106,7 +104,7 @@ const handleSubmit = (event: FormSubmitEvent<v.InferOutput<typeof formSchema>>) 
 			</UForm>
 		</template>
 		<template #footer>
-			<UButton label="Cancel" color="error" variant="soft" @click="handleCloseCreateBoardModal" />
+			<CancelButton @cancel="handleCloseCreateBoardModal" />
 			<UButton label="Create board" color="primary" @click="handleSubmitCreateBoard" />
 		</template>
 	</UModal>

--- a/app/components/molecules/EditBoardModal/EditBoardModal.test.ts
+++ b/app/components/molecules/EditBoardModal/EditBoardModal.test.ts
@@ -283,10 +283,13 @@ describe('EditBoardModal', () => {
 				expect(buttons[1].text()).toBe('Close');
 				expect(buttons[2].text()).toBe('Edit');
 
+				expect(wrapper.find('h2').text()).toBe('Board Overview');
 				const editButton = buttons.find(btn => btn.text() === 'Edit');
 				expect(editButton).toBeTruthy();
 				await editButton!.trigger('click');
 				await modal.vm.$nextTick();
+				expect(wrapper.find('h2').text()).toBe('Editing Board');
+
 
 				inputs = wrapper.findAll('input');
 				for (const input of inputs) {
@@ -446,6 +449,7 @@ describe('EditBoardModal', () => {
 		});
 
 		const wrapper = new DOMWrapper(document.querySelector('[role="dialog"]'));
+		expect(wrapper.find('h2').text()).toBe('Board Overview');
 
 		// Enter edit mode
 		let buttons = wrapper.findAll('button');
@@ -453,6 +457,7 @@ describe('EditBoardModal', () => {
 		expect(editButton).toBeTruthy();
 		await editButton!.trigger('click');
 		await modal.vm.$nextTick();
+		expect(wrapper.find('h2').text()).toBe('Editing Board');
 
 		// Change name and description
 		let inputs = wrapper.findAll('input');
@@ -465,7 +470,7 @@ describe('EditBoardModal', () => {
 		await modal.vm.$nextTick();
 
 		// Add a tag
-		const tagInput = inputs.find(input => (input.element as HTMLInputElement).name === 'tag');
+		let tagInput = inputs.find(input => (input.element as HTMLInputElement).name === 'tag');
 		expect(tagInput).toBeTruthy();
 		await tagInput!.setValue('newtag');
 		await tagInput!.trigger('keydown', { key: 'Enter' });
@@ -476,6 +481,7 @@ describe('EditBoardModal', () => {
 		const updateButton = buttons.find(btn => btn.text() === 'Update');
 		expect(updateButton).toBeTruthy();
 		await updateButton!.trigger('click');
+		await modal.vm.$nextTick();
 		await modal.vm.$nextTick();
 		await modal.vm.$nextTick();
 		await modal.vm.$nextTick();
@@ -491,6 +497,7 @@ describe('EditBoardModal', () => {
 		);
 
 		// Should exit edit mode (inputs become readonly again)
+		expect(wrapper.find('h2').text()).toBe('Board Overview');
 		inputs = wrapper.findAll('input');
 		for (const input of inputs) {
 			expect((input.element as HTMLInputElement).readOnly).toBe(true);

--- a/app/components/molecules/ExpandedCardModal/ExpandedCardModal.vue
+++ b/app/components/molecules/ExpandedCardModal/ExpandedCardModal.vue
@@ -101,21 +101,17 @@ const handleSubmitCardChanges = () => {
 		</template>
 		<template #footer>
 			<div class="w-full flex justify-between items-center gap-2">
-				<UButton v-if="!expandedCard?.archived && !isEditing" label="Archive" color="secondary" variant="ghost"
-					@click="handleArchiveCard" />
-				<UButton v-else-if="expandedCard?.archived && !isEditing" label="Unarchive" color="secondary"
-					variant="ghost" @click="handleUnarchiveCard" />
+				<ArchiveButton v-if="!expandedCard?.archived && !isEditing" @archive="handleArchiveCard" />
+				<UnarchiveButton v-else-if="expandedCard?.archived && !isEditing" @unarchive="handleUnarchiveCard" />
 				<div v-if="!expandedCard?.archived" class="flex gap-2 ml-auto">
-					<UButton v-if="isEditing" label="Cancel" color="error" variant="soft"
-						@click="handleCancelCardChanges" />
-					<UButton v-else label="Close" color="neutral" variant="ghost"
-						@click="handleCloseCardModal" />
-					<UButton v-if="isEditing" label="Update" :color="'primary'" @click="handleUpdateCard" />
-					<UButton v-else label="Edit" color="secondary" @click="handleEditCard" />
+					<CancelButton v-if="isEditing" @cancel="handleCancelCardChanges" />
+					<CloseButton v-else @close="handleCloseCardModal" />
+					<UpdateButton v-if="isEditing" @update="handleUpdateCard" />
+					<EditButton v-else @edit="handleEditCard" />
 				</div>
 				<div v-else class="flex gap-2">
-					<UButton label="Close" color="neutral" variant="ghost" @click="handleCloseCardModal" />
-					<UButton label="Delete" color="error" variant="soft" @click="handleDeleteCard" />
+					<CloseButton @close="handleCloseCardModal" />
+					<DeleteButton @delete="handleDeleteCard" />
 				</div>
 			</div>
 		</template>

--- a/app/components/organisms/Board/Board.vue
+++ b/app/components/organisms/Board/Board.vue
@@ -73,6 +73,6 @@ const handleCloseEditBoardModal = () => {
 	</ActionMenu>
 
 	<!-- modals -->
-	<EditBoardModal v-model:open="isEditBoardModalOpen" @close="handleCloseEditBoardModal" :boardId="boardId" />
+	<EditBoardModal :open="isEditBoardModalOpen" @close="handleCloseEditBoardModal" :boardId="boardId" />
 	<ExpandedCardModal />
 </template>


### PR DESCRIPTION
This PR reduces the usage of `<UButton>` components. It creates the following reusable button components used in molecule and organism components:

- Archive button
- Unarchive button
- Cancel button
- Close button
- Delete button
- Edit button
- Update button